### PR TITLE
1.6.8 - Remove despawn distance for previews as affecting larger designs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'io.github.bl3rune'
-version = '1.6.7'
+version = '1.6.8'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/github/bl3rune/blu3printPlugin/items/Hologram.java
+++ b/src/main/java/io/github/bl3rune/blu3printPlugin/items/Hologram.java
@@ -96,7 +96,6 @@ public class Hologram {
             a.setCanPickupItems(false);
             a.setMarker(true);
             a.setPersistent(false);
-            a.setRemoveWhenFarAway(true);
             a.setSmall(true);
             a.getEquipment().setHelmet(new ItemStack(data.getMaterial()));
             a.teleport(new Location(l.getWorld(), l.getX(), l.getY() - 0.5, l.getZ()));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Blu3PrintPlugin
-version: '1.6.7'
+version: '1.6.8'
 main: io.github.bl3rune.blu3printPlugin.Blu3PrintPlugin
 api-version: '1.18'
 prefix: Blu3Print


### PR DESCRIPTION
# Description
Remove despawn distance for previews as affecting larger designs

# Checklist
- [x] Does this need an immediate release?
- [ ] Is this for the repo only?
